### PR TITLE
Record book page load times in statsd

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -35,7 +35,7 @@ from infogami.infobase.client import Thing, Changeset, storify
 
 from openlibrary.core.helpers import commify, parse_datetime, truncate
 from openlibrary.core.middleware import GZipMiddleware
-from openlibrary.core import cache, ab
+from openlibrary.core import cache, ab, stats as ol_stats
 
 
 class MultiDict(MutableMapping):
@@ -981,6 +981,13 @@ def render_once(key):
 @public
 def today():
     return datetime.datetime.today()
+
+
+@public
+def set_stats(stats_key, value):
+    """ Creates statsd entry.
+    """
+    ol_stats.put(stats_key, value)
 
 
 class HTMLTagRemover(HTMLParser):

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -503,6 +503,8 @@ $if is_privileged_user:
 
   $ component_times['TotalTime'] = time() - component_times['TotalTime']
 
+  $ set_stats('ol.template.edition-view.load-time', component_times['TotalTime'])
+
   $if query_param('debug'):
     $:macros.Profile(component_times)
 


### PR DESCRIPTION
Would something like this be useful?  I'm not convinced that the load times that I'm seeing in Grafana are accurate.  Maybe we can create a graph with book page load times.

For reference, `ol_stats.put` is here:
https://github.com/jimchamp/openlibrary/blob/0f8f394a2a1ad8e1ebf7d026e5919ae1a6af0acd/openlibrary/core/stats.py#L39-L44