### PR TITLE
`/partials` handler updates

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,4 +1,5 @@
 import json
+from abc import abstractmethod, ABC
 from urllib.parse import parse_qs
 
 import web
@@ -15,27 +16,51 @@ from openlibrary.utils import dateutil
 from openlibrary.views.loanstats import get_trending_books
 
 
-def _get_relatedcarousels_component(workid):
-    if 'env' not in web.ctx:
-        delegate.fakeload()
-    work = web.ctx.site.get('/works/%s' % workid) or {}
-    component = render_template('books/RelatedWorksCarousel', work)
-    return {0: str(component)}
+class PartialResolutionError(Exception):
+    pass
 
 
-def get_cached_relatedcarousels_component(*args, **kwargs):
-    memoized_get_component_metadata = cache.memcache_memoize(
-        _get_relatedcarousels_component,
-        "book.bookspage.component.relatedcarousels",
-        timeout=dateutil.HALF_DAY_SECS,
-    )
-    return (
-        memoized_get_component_metadata(*args, **kwargs)
-        or memoized_get_component_metadata.update(*args, **kwargs)[0]
-    )
+class PartialDataHandler(ABC):
+    """Base class for partial data handlers.
+
+    Has a single method, `generate`, that is expected to return a
+    JSON-serializable dict that contains data necessary to update
+    a page.
+    """
+    @abstractmethod
+    def generate(self) -> dict:
+        pass
 
 
-class CarouselCardPartial:
+class RelatedWorksPartial(PartialDataHandler):
+    """Handler for the related works carousels."""
+    def __init__(self):
+        self.i = web.input(workid=None)
+
+    def generate(self) -> dict:
+        return self._get_relatedcarousels_component(self.i.workid)
+
+    def _get_relatedcarousels_component(self, workid) -> dict:
+        if 'env' not in web.ctx:
+            delegate.fakeload()
+        work = web.ctx.site.get('/works/%s' % workid) or {}
+        component = render_template('books/RelatedWorksCarousel', work)
+        return {0: str(component)}
+
+    def _get_cached_relatedcarousels_component(self, *args, **kwargs):
+        memoized_get_component_metadata = cache.memcache_memoize(
+            self._get_relatedcarousels_component,
+            "book.bookspage.component.relatedcarousels",
+            timeout=dateutil.HALF_DAY_SECS,
+        )
+        return (
+            memoized_get_component_metadata(*args, **kwargs)
+            or memoized_get_component_metadata.update(*args, **kwargs)[0]
+        )
+
+
+class CarouselCardPartial(PartialDataHandler):
+    """Handler for carousel "load_more" requests"""
     def __init__(self):
         self.i = web.input(params=None)
 
@@ -110,83 +135,123 @@ class CarouselCardPartial:
         return subject.get("works", [])
 
 
+class AffiliateLinksPartial(PartialDataHandler):
+    """Handler for affiliate links"""
+
+    def __init__(self):
+        self.i = web.input(data=None)
+
+    def generate(self) -> dict:
+        data = json.loads(self.i.data)
+        args = data.get("args", [])
+
+        if len(args) < 2:
+            raise PartialResolutionError("Unexpected amount of arguments")
+
+        macro = web.template.Template.globals['macros'].AffiliateLinks(
+            args[0], args[1]
+        )
+        return {"partials": str(macro)}
+
+
+class SearchFacetsPartial(PartialDataHandler):
+    """Handler for search facets sidebar and "selected facets" affordances."""
+
+    def __init__(self):
+        self.i = web.input(data=None)
+
+    def generate(self) -> dict:
+        data = json.loads(self.i.data)
+        path = data.get('path')
+        query = data.get('query', '')
+        parsed_qs = parse_qs(query.replace('?', ''))
+        param = data.get('param', {})
+
+        sort = None
+        search_response = do_search(
+            param, sort, rows=0, spellcheck_count=3, facet=True
+        )
+
+        sidebar = render_template(
+            'search/work_search_facets',
+            param,
+            facet_counts=search_response.facet_counts,
+            async_load=False,
+            path=path,
+            query=parsed_qs,
+        )
+
+        active_facets = render_template(
+            'search/work_search_selected_facets',
+            param,
+            search_response,
+            param.get('q', ''),
+            path=path,
+            query=parsed_qs,
+        )
+
+        return {
+            "sidebar": str(sidebar),
+            "title": active_facets.title,
+            "activeFacets": str(active_facets).strip(),
+        }
+
+
+class FullTextSuggestionsPartial(PartialDataHandler):
+    """Handler for rendering full-text search suggestions."""
+
+    def __init__(self):
+        self.i = web.input(data=None)
+
+    def generate(self) -> dict:
+        query = self.i.get("data", "")
+        data = fulltext_search(query)
+        # Add caching headers only if there were no errors in the search results
+        if 'error' not in data:
+            # Cache for 5 minutes (300 seconds)
+            web.header('Cache-Control', 'public, max-age=300')
+        hits = data.get('hits', [])
+        if not hits['hits']:
+            macro = '<div></div>'
+        else:
+            macro = web.template.Template.globals[
+                'macros'
+            ].FulltextSearchSuggestion(query, data)
+        return {"partials": str(macro)}
+
+
+class PartialRequestResolver:
+    # Maps `_component` values to PartialDataHandler subclasses
+    component_mapping = {
+        "RelatedWorkCarousel": RelatedWorksPartial,
+        "CarouselLoadMore": CarouselCardPartial,
+        "AffiliateLinks": AffiliateLinksPartial,
+        "SearchFacets": SearchFacetsPartial,
+        "FulltextSearchSuggestion": FullTextSuggestionsPartial,
+    }
+
+    @staticmethod
+    def resolve(component: str) -> dict:
+        """Gets an instantiated PartialDataHandler and returns its generated dict"""
+        handler = PartialRequestResolver.get_handler(component)
+        return handler.generate()
+
+    @classmethod
+    def get_handler(cls, component: str) -> PartialDataHandler:
+        """Instantiates and returns the requested handler"""
+        if klass := cls.component_mapping.get(component):
+            return klass()
+        raise PartialResolutionError(f'No handler found for key "{component}"')
+
+
 class Partials(delegate.page):
     path = '/partials'
     encoding = 'json'
 
     def GET(self):
-        # `data` is meant to be a dict with two keys: `args` and `kwargs`.
-        # `data['args']` is meant to be a list of a template's positional arguments, in order.
-        # `data['kwargs']` is meant to be a dict containing a template's keyword arguments.
-        i = web.input(workid=None, _component=None, data=None)
+        i = web.input(_component=None)
         component = i.pop("_component")
-        partial = {}
-        if component == "RelatedWorkCarousel":
-            partial = _get_relatedcarousels_component(i.workid)
-        elif component == "CarouselLoadMore":
-            partial = CarouselCardPartial().generate()
-        elif component == "AffiliateLinks":
-            data = json.loads(i.data)
-            args = data.get('args', [])
-            # XXX : Throw error if args length is less than 2
-            macro = web.template.Template.globals['macros'].AffiliateLinks(
-                args[0], args[1]
-            )
-            partial = {"partials": str(macro)}
-
-        elif component == 'SearchFacets':
-            data = json.loads(i.data)
-            path = data.get('path')
-            query = data.get('query', '')
-            parsed_qs = parse_qs(query.replace('?', ''))
-            param = data.get('param', {})
-
-            sort = None
-            search_response = do_search(
-                param, sort, rows=0, spellcheck_count=3, facet=True
-            )
-
-            sidebar = render_template(
-                'search/work_search_facets',
-                param,
-                facet_counts=search_response.facet_counts,
-                async_load=False,
-                path=path,
-                query=parsed_qs,
-            )
-
-            active_facets = render_template(
-                'search/work_search_selected_facets',
-                param,
-                search_response,
-                param.get('q', ''),
-                path=path,
-                query=parsed_qs,
-            )
-
-            partial = {
-                "sidebar": str(sidebar),
-                "title": active_facets.title,
-                "activeFacets": str(active_facets).strip(),
-            }
-
-        elif component == "FulltextSearchSuggestion":
-            query = i.get('data', '')
-            data = fulltext_search(query)
-            # Add caching headers only if there were no errors in the search results
-            if 'error' not in data:
-                # Cache for 5 minutes (300 seconds)
-                web.header('Cache-Control', 'public, max-age=300')
-            hits = data.get('hits', [])
-            if not hits['hits']:
-                macro = '<div></div>'
-            else:
-                macro = web.template.Template.globals[
-                    'macros'
-                ].FulltextSearchSuggestion(query, data)
-            partial = {"partials": str(macro)}
-
-        return delegate.RawText(json.dumps(partial))
+        return delegate.RawText(json.dumps(PartialRequestResolver.resolve(component)))
 
 def setup():
     pass


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the `/partials.json` handler in hopes of making future partial development easier.

Each type of partial request is now handled by a subclass of `PartialDataHandler`, which has a `generate` method which is meant to return a JSON-serializable `dict` containing the partial data. Passing a valid `_component` key to `PartialRequestResolver.resolve()` will return the correct `PartialDataHandler.generate()` output.

With this in place, we can update the `/partials.json` handler to return new partials by doing the following:

1. Create a new subclass of `PartialDataHandler`
2. Write a `generate()` method for the new class
3. Add the new class and `_component` name to the `PartialRequestResolver.component_mapping` dict

__Example:__
Adding the following would cause `/partials?_component=Pointless` to return `{"partials": "<div>why?</div>}`:

```python
class PointlessPartial(PartialDataHandler):
  def generate(self):
    return {"partials": "<div>why?</div>"}

# ...


class PartialRequestResolver:
  component_mapping = {
    # ...
    "Pointless": PointlessPartial,
  }
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The `/partials.json` endpoint should continue to serve the correct partials without error.

- [ ] Do the book page related work carousels load?
- [ ] Do the book page affiliate links load?
- [ ] Can carousels load more cards?
- [ ] Do the facets load on search pages?
- [ ] Are full-text search suggestions displayed when there are no search results?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
